### PR TITLE
Replace Streamlit app with FastAPI front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.DS_Store
+.pytest_cache/
+.streamlit/

--- a/app.py
+++ b/app.py
@@ -51,7 +51,16 @@ global_config = loader.fetch_json("TbHomeGlobalConfig")
 BASE_WEEKLY_LIMIT = int(global_config.get("home_money_max", 100000))
 
 ALL_PROFILES = calculator.supported_profiles()
-MODELLED_PROFILES = [profile for profile in ALL_PROFILES if profile.category in MODELLED_CATEGORIES]
+def _is_modelled(profile: ProductionProfile) -> bool:
+    if profile.category not in MODELLED_CATEGORIES:
+        return False
+    for minutes in profile.facility_minutes.values():
+        if minutes and math.isfinite(minutes) and minutes > 0:
+            return True
+    return False
+
+
+MODELLED_PROFILES = [profile for profile in ALL_PROFILES if _is_modelled(profile)]
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,329 @@
+"""FastAPI backend and static front-end for the Astralite optimiser."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Dict, List, Mapping
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field, field_validator
+
+from astralite_optimizer.data_loader import RemoteDataLoader
+from astralite_optimizer.localization import Localization
+from astralite_optimizer.optimizer import optimise_portfolio
+from astralite_optimizer.production import (
+    CRAFT_FACILITY,
+    FISH_FACILITY,
+    PLANT_FACILITY,
+    ProductionCalculator,
+    ProductionProfile,
+    WEEK_MINUTES,
+)
+from astralite_optimizer.progression import ProgressionRepository
+
+ABILITY_LABELS: Mapping[int, str] = {
+    22: "Construction",
+    34: "Planting",
+    45: "Star Collecting",
+    47: "Fish Keeping",
+    48: "Animal Inviting",
+}
+MODELLED_CATEGORIES = {"plant", "fish", "furniture"}
+FARMLAND_ITEMS = (1170000320, 1170000321, 1170000322, 1170000323)
+FISH_POND_ITEMS = (1170000419,)
+FACILITY_NAMES = {
+    PLANT_FACILITY: "Plant plots",
+    FISH_FACILITY: "Fish ponds",
+    CRAFT_FACILITY: "Crafting queue",
+}
+
+loader = RemoteDataLoader()
+localisation = Localization(loader.fetch_json("en"))
+progression = ProgressionRepository(
+    loader.fetch_json("TbHomeAbilityLevelUpRewardShowInfo"),
+    loader.fetch_json("TbHomeAbilityTotalLevelValueInfo"),
+)
+calculator = ProductionCalculator(loader, localisation)
+global_config = loader.fetch_json("TbHomeGlobalConfig")
+BASE_WEEKLY_LIMIT = int(global_config.get("home_money_max", 100000))
+
+ALL_PROFILES = calculator.supported_profiles()
+MODELLED_PROFILES = [profile for profile in ALL_PROFILES if profile.category in MODELLED_CATEGORIES]
+
+STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+app = FastAPI(title="Astralite Optimiser API")
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+def _safe_minutes(value: float) -> float:
+    if value is None or not math.isfinite(value):
+        return 0.0
+    return float(value)
+
+
+def _minutes_map(source: Mapping[str, float]) -> Dict[str, float]:
+    return {
+        facility: round(_safe_minutes(minutes), 4)
+        for facility, minutes in source.items()
+        if math.isfinite(minutes) and minutes > 0
+    }
+
+
+def _profile_detail(profile: ProductionProfile) -> Dict[str, object]:
+    detail: Dict[str, object] = {"category": profile.category}
+    if profile.category == "plant":
+        growth = calculator.plant_growth.get(profile.item_id)
+        if growth:
+            detail["growth_minutes"] = round(growth.cycle_minutes, 4)
+            detail["average_yield"] = round(growth.average_yield, 4)
+            detail["seed_id"] = growth.seed_id
+            if growth.farmland_ids:
+                detail["farmland_ids"] = growth.farmland_ids
+    elif profile.category == "fish":
+        growth = calculator.fish_growth.get(profile.item_id)
+        if growth:
+            detail["growth_minutes"] = round(growth.cycle_minutes, 4)
+            detail["fry_id"] = growth.fry_id
+    elif profile.category == "furniture":
+        craft_minutes = profile.facility_minutes.get(CRAFT_FACILITY)
+        if craft_minutes and math.isfinite(craft_minutes):
+            detail["craft_minutes"] = round(craft_minutes, 4)
+    return detail
+
+
+def _component_dict(component) -> Dict[str, object]:
+    profile = component.profile
+    per_unit_minutes: Dict[str, float] = {}
+    total_minutes: Dict[str, float] = {}
+    notes: List[str] = []
+    category: str | None = None
+    profile_item_id: int | None = None
+    if profile:
+        profile_item_id = profile.item_id
+        category = profile.category
+        for facility, minutes in profile.facility_minutes.items():
+            if not math.isfinite(minutes) or minutes <= 0:
+                continue
+            per_unit_minutes[facility] = round(minutes, 4)
+            total_minutes[facility] = round(minutes * component.quantity, 4)
+        notes = profile.notes
+    return {
+        "item_id": component.item_id,
+        "name": component.name,
+        "quantity": component.quantity,
+        "exchange_cost": component.exchange_cost,
+        "category": category,
+        "profile_item_id": profile_item_id,
+        "facility_minutes": per_unit_minutes,
+        "total_facility_minutes": total_minutes,
+        "notes": notes,
+    }
+
+
+def _profile_dict(profile: ProductionProfile) -> Dict[str, object]:
+    return {
+        "item_id": profile.item_id,
+        "name": profile.name,
+        "sale_value": profile.sale_value,
+        "ability_id": profile.ability_id,
+        "ability_level": profile.ability_level,
+        "category": profile.category,
+        "facility_minutes": _minutes_map(profile.facility_minutes),
+        "notes": profile.notes,
+        "components": [_component_dict(component) for component in profile.components],
+        "detail": _profile_detail(profile),
+    }
+
+
+class AbilityModel(BaseModel):
+    id: int
+    label: str
+    max_level: int
+
+
+class ProfileModel(BaseModel):
+    item_id: int
+    name: str
+    sale_value: float
+    ability_id: int
+    ability_level: int
+    category: str
+    facility_minutes: Dict[str, float]
+    notes: List[str] = Field(default_factory=list)
+    components: List[Dict[str, object]] = Field(default_factory=list)
+    detail: Dict[str, object] = Field(default_factory=dict)
+
+
+class InitResponse(BaseModel):
+    abilities: List[AbilityModel]
+    base_weekly_limit: int
+    facility_names: Dict[str, str]
+    items: List[ProfileModel]
+    modelled_categories: List[str]
+
+
+class PlanItemModel(BaseModel):
+    item_id: int
+    name: str
+    category: str
+    units: float
+    astralite: float
+    multiplier: float
+    per_unit_value: float
+    facility_minutes: Dict[str, float]
+    per_unit_facility_minutes: Dict[str, float]
+
+
+class OptimiseResponse(BaseModel):
+    status: str
+    weekly_limit: float
+    weekly_bonus: float
+    ability_total: int
+    plant_plots: int
+    fish_ponds: int
+    crafting_slots: int
+    items: List[PlanItemModel]
+    facility_usage: Dict[str, Dict[str, float]]
+    capacities: Dict[str, Dict[str, float]]
+    unlocked_item_ids: List[int]
+    message: str | None = None
+
+
+class OptimiseRequest(BaseModel):
+    ability_levels: Dict[int, int] = Field(default_factory=dict)
+    bonus_item_ids: List[int] = Field(default_factory=list)
+    crafting_slots: int = Field(1, ge=1)
+
+    @field_validator("ability_levels", mode="before")
+    def _convert_ability_keys(cls, value):
+        if isinstance(value, dict):
+            return {int(key): int(level) for key, level in value.items()}
+        return value
+
+    @field_validator("bonus_item_ids", mode="before")
+    def _convert_bonus_ids(cls, value):
+        if isinstance(value, list):
+            return [int(item) for item in value]
+        return value
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> FileResponse:
+    index_path = STATIC_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="Front-end not built yet")
+    return FileResponse(index_path)
+
+
+@app.get("/api/init", response_model=InitResponse)
+async def api_init() -> InitResponse:
+    abilities = [
+        AbilityModel(
+            id=ability_id,
+            label=label,
+            max_level=progression.max_level(ability_id),
+        )
+        for ability_id, label in ABILITY_LABELS.items()
+    ]
+    items = [
+        ProfileModel(**_profile_dict(profile))
+        for profile in sorted(MODELLED_PROFILES, key=lambda prof: prof.name)
+    ]
+    return InitResponse(
+        abilities=abilities,
+        base_weekly_limit=BASE_WEEKLY_LIMIT,
+        facility_names=FACILITY_NAMES,
+        items=items,
+        modelled_categories=sorted(MODELLED_CATEGORIES),
+    )
+
+
+def _facility_payload(data: Mapping[str, float]) -> Dict[str, Dict[str, float]]:
+    payload: Dict[str, Dict[str, float]] = {}
+    for facility, minutes in data.items():
+        safe_minutes = _safe_minutes(minutes)
+        payload[facility] = {
+            "minutes": round(safe_minutes, 4),
+            "hours": round(safe_minutes / 60.0, 4),
+        }
+    return payload
+
+
+@app.post("/api/optimise", response_model=OptimiseResponse)
+async def api_optimise(payload: OptimiseRequest) -> OptimiseResponse:
+    ability_levels: Dict[int, int] = {}
+    for ability_id in ABILITY_LABELS:
+        requested = payload.ability_levels.get(ability_id, 0)
+        max_level = progression.max_level(ability_id)
+        if max_level:
+            ability_levels[ability_id] = max(0, min(int(requested), max_level))
+        else:
+            ability_levels[ability_id] = max(0, int(requested))
+
+    total_level = sum(ability_levels.values())
+    weekly_bonus = progression.weekly_bonus_for_total_level(total_level)
+    weekly_limit = BASE_WEEKLY_LIMIT + weekly_bonus
+
+    plant_plots = progression.sum_item_counts(34, ability_levels.get(34, 0), FARMLAND_ITEMS)
+    fish_ponds = progression.sum_item_counts(47, ability_levels.get(47, 0), FISH_POND_ITEMS)
+    crafting_slots = max(payload.crafting_slots, 1)
+
+    capacities = {
+        PLANT_FACILITY: plant_plots * WEEK_MINUTES,
+        FISH_FACILITY: fish_ponds * WEEK_MINUTES,
+        CRAFT_FACILITY: crafting_slots * WEEK_MINUTES,
+    }
+
+    unlocked_profiles = [
+        profile
+        for profile in MODELLED_PROFILES
+        if ability_levels.get(profile.ability_id, 0) >= profile.ability_level
+    ]
+
+    bonus_ids = set(payload.bonus_item_ids[:4])
+    result = optimise_portfolio(unlocked_profiles, weekly_limit, capacities, bonus_ids)
+
+    plan_items = [
+        PlanItemModel(
+            item_id=item.item_id,
+            name=item.name,
+            category=item.profile.category,
+            units=round(item.units, 4),
+            astralite=round(item.astralite, 4),
+            multiplier=item.multiplier,
+            per_unit_value=round(item.profile.sale_value * item.multiplier, 4),
+            facility_minutes=_minutes_map(item.facility_minutes),
+            per_unit_facility_minutes=_minutes_map(item.profile.facility_minutes),
+        )
+        for item in result.items
+    ]
+
+    message: str | None = None
+    if not plan_items:
+        if not unlocked_profiles:
+            message = "Increase ability levels to unlock saleable items."
+        else:
+            message = "No feasible plan within the current facility limits."
+
+    facility_usage = _facility_payload(result.facility_usage)
+    capacities_payload = _facility_payload(capacities)
+
+    return OptimiseResponse(
+        status=result.status,
+        weekly_limit=weekly_limit,
+        weekly_bonus=weekly_bonus,
+        ability_total=total_level,
+        plant_plots=plant_plots,
+        fish_ponds=fish_ponds,
+        crafting_slots=crafting_slots,
+        items=plan_items,
+        facility_usage=facility_usage,
+        capacities=capacities_payload,
+        unlocked_item_ids=[profile.item_id for profile in unlocked_profiles],
+        message=message,
+    )

--- a/astralite_optimizer/__init__.py
+++ b/astralite_optimizer/__init__.py
@@ -1,0 +1,6 @@
+"""Tools for optimising Astralite exchange planning."""
+
+from .config import DATA_URLS
+from .data_loader import RemoteDataLoader
+
+__all__ = ["DATA_URLS", "RemoteDataLoader"]

--- a/astralite_optimizer/config.py
+++ b/astralite_optimizer/config.py
@@ -1,0 +1,24 @@
+"""Configuration for remote Astralite data sources."""
+
+from __future__ import annotations
+
+DATA_URLS = {
+    "TbFurnitureMakeMaterialExchangeInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbFurnitureMakeMaterialExchangeInfo.json",
+    "TbFurnitureTableMakeInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbFurnitureTableMakeInfo.json",
+    "TbGamePlayItemsMakeInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbGamePlayItemsMakeInfo.json",
+    "TbHomeAbilityLevelUpRewardShowInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeAbilityLevelUpRewardShowInfo.json",
+    "TbHomeAbilityTotalLevelValueInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeAbilityTotalLevelValueInfo.json",
+    "TbHomeAnimalFoodCfg": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeAnimalFoodCfg.json",
+    "TbHomeAnimalGameplay": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeAnimalGameplay.json",
+    "TbHomeAnimalHabitatCfg": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeAnimalHabitatCfg.json",
+    "TbHomeFishGrowthConfig": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeFishGrowthConfig.json",
+    "TbHomeFishNutrientConfig": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeFishNutrientConfig.json",
+    "TbHomeGlobalConfig": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeGlobalConfig.json",
+    "TbHomeMiningMineralProficiency": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeMiningMineralProficiency.json",
+    "TbHomeProductsSaleInfo": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbHomeProductsSaleInfo.json",
+    "TbPlantingGrowthProcess": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbPlantingGrowthProcess.json",
+    "TbPlantingNutrient": "https://github.com/kateberly/Astralite/raw/refs/heads/main/TbPlantingNutrient.json",
+    "en": "https://github.com/kateberly/Astralite/raw/refs/heads/main/en.json",
+}
+"""Mapping of dataset name to the corresponding raw GitHub URL."""
+

--- a/astralite_optimizer/data_loader.py
+++ b/astralite_optimizer/data_loader.py
@@ -1,0 +1,39 @@
+"""Utilities for retrieving Astralite gameplay data from GitHub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping
+
+import requests
+
+from .config import DATA_URLS
+
+
+@dataclass(slots=True)
+class RemoteDataLoader:
+    """Fetches JSON blobs from the public Astralite data repository."""
+
+    session: requests.Session | None = None
+    urls: Mapping[str, str] = field(default_factory=lambda: DATA_URLS.copy())
+    _session: requests.Session = field(init=False, repr=False)
+    _cache: Dict[str, Any] = field(init=False, repr=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._session = self.session or requests.Session()
+
+    def fetch_json(self, name: str) -> Any:
+        """Return the parsed JSON for ``name`` from the configured URLs."""
+
+        if name not in self.urls:
+            raise KeyError(f"Unknown dataset: {name}")
+        if name not in self._cache:
+            response = self._session.get(self.urls[name], timeout=30)
+            response.raise_for_status()
+            self._cache[name] = response.json()
+        return self._cache[name]
+
+    # Convenience aliases for clarity when reading call sites.
+    def __call__(self, name: str) -> Any:  # pragma: no cover - trivial alias
+        return self.fetch_json(name)
+

--- a/astralite_optimizer/localization.py
+++ b/astralite_optimizer/localization.py
@@ -1,0 +1,47 @@
+"""Helpers for working with the English localisation dictionary."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, Dict, Mapping
+
+
+class Localization:
+    """Provides convenient access to localisation keys.
+
+    The supplied ``data`` is the parsed ``en.json`` blob.  The structure is
+    deeply nested, so we eagerly flatten all keys to enable efficient lookups
+    later in the optimiser.
+    """
+
+    def __init__(self, data: Mapping[str, Any]) -> None:
+        self._flat: Dict[str, str] = {}
+        self._flatten(data)
+
+    def _flatten(self, data: Any) -> None:
+        if isinstance(data, Mapping):
+            for key, value in data.items():
+                if isinstance(value, (Mapping, list)):
+                    self._flatten(value)
+                elif isinstance(value, str):
+                    self._flat[key] = value
+        elif isinstance(data, list):
+            for item in data:
+                self._flatten(item)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._flat.get(key, default)
+
+    def item_name(self, item_id: int | str) -> str:
+        key = f"ItemName_{int(item_id)}"
+        return self._flat.get(key, f"Item {item_id}")
+
+    def item_desc(self, item_id: int | str) -> str | None:
+        return self._flat.get(f"ItemDesc_{int(item_id)}")
+
+    def ability_text(self, key: str) -> str | None:
+        return self._flat.get(key)
+
+    def find_any(self, keys: Iterable[str]) -> Dict[str, str]:
+        return {key: self._flat[key] for key in keys if key in self._flat}
+

--- a/astralite_optimizer/optimizer.py
+++ b/astralite_optimizer/optimizer.py
@@ -1,0 +1,118 @@
+"""Optimisation helpers for maximising Astralite within weekly limits."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Set
+
+from pulp import LpMaximize, LpProblem, LpStatus, LpVariable, PULP_CBC_CMD, lpSum
+
+from .production import ProductionProfile
+
+
+@dataclass(slots=True)
+class OptimizedItem:
+    item_id: int
+    name: str
+    units: float
+    astralite: float
+    multiplier: float
+    facility_minutes: Dict[str, float]
+    profile: ProductionProfile
+
+
+@dataclass(slots=True)
+class OptimizationResult:
+    items: List[OptimizedItem]
+    total_astralite: float
+    facility_usage: Dict[str, float]
+    status: str
+
+
+def optimise_portfolio(
+    profiles: Sequence[ProductionProfile],
+    weekly_limit: float,
+    capacities: Mapping[str, float],
+    bonus_item_ids: Iterable[int] | None = None,
+) -> OptimizationResult:
+    """Solve a linear programme that maximises Astralite under the constraints."""
+
+    if weekly_limit <= 0 or not profiles:
+        return OptimizationResult([], 0.0, {}, "No capacity")
+
+    bonus_set: Set[int] = set(bonus_item_ids or [])
+    variables = {
+        profile.item_id: LpVariable(f"x_{profile.item_id}", lowBound=0)
+        for profile in profiles
+        if profile.sale_value > 0
+    }
+    if not variables:
+        return OptimizationResult([], 0.0, {}, "No variables")
+
+    def item_multiplier(profile: ProductionProfile) -> float:
+        return 1.2 if profile.item_id in bonus_set else 1.0
+
+    def item_value(profile: ProductionProfile) -> float:
+        return profile.sale_value * item_multiplier(profile)
+
+    ordered_profiles = [profile for profile in profiles if profile.item_id in variables]
+    problem = LpProblem("AstraliteOptimisation", LpMaximize)
+    problem += lpSum(item_value(profile) * variables[profile.item_id] for profile in ordered_profiles)
+
+    # Facility capacity constraints
+    for facility, capacity in capacities.items():
+        if capacity is None or capacity <= 0:
+            continue
+        problem += (
+            lpSum(
+                profile.facility_minutes.get(facility, 0.0) * variables[profile.item_id]
+                for profile in ordered_profiles
+            )
+            <= capacity
+        )
+
+    # Weekly Astralite cap constraint
+    problem += (
+        lpSum(item_value(profile) * variables[profile.item_id] for profile in ordered_profiles)
+        <= weekly_limit
+    )
+
+    status_code = problem.solve(PULP_CBC_CMD(msg=False))
+    status = LpStatus.get(status_code, str(status_code))
+
+    items: List[OptimizedItem] = []
+    facility_usage: Dict[str, float] = {facility: 0.0 for facility in capacities}
+    total_astralite = 0.0
+
+    if status_code in (1, "Optimal"):
+        for profile in ordered_profiles:
+            value = variables[profile.item_id].value() or 0.0
+            if value <= 1e-6:
+                continue
+            multiplier = item_multiplier(profile)
+            astralite = item_value(profile) * value
+            usage = {
+                facility: minutes * value
+                for facility, minutes in profile.facility_minutes.items()
+                if minutes > 0
+            }
+            for facility, amount in usage.items():
+                facility_usage[facility] = facility_usage.get(facility, 0.0) + amount
+            total_astralite += astralite
+            items.append(
+                OptimizedItem(
+                    item_id=profile.item_id,
+                    name=profile.name,
+                    units=value,
+                    astralite=astralite,
+                    multiplier=multiplier,
+                    facility_minutes=usage,
+                    profile=profile,
+                )
+            )
+        items.sort(key=lambda item: item.astralite, reverse=True)
+    else:
+        facility_usage.clear()
+
+    return OptimizationResult(items=items, total_astralite=total_astralite, facility_usage=facility_usage, status=status)
+

--- a/astralite_optimizer/production.py
+++ b/astralite_optimizer/production.py
@@ -1,0 +1,366 @@
+"""Logic for stitching gameplay datasets into production profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+import re
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+from .data_loader import RemoteDataLoader
+from .localization import Localization
+
+ABILITY_CATEGORY = {
+    22: "furniture",
+    34: "plant",
+    45: "meteor",
+    47: "fish",
+    48: "animal",
+}
+
+PLANT_FACILITY = "plant_plot"
+FISH_FACILITY = "fish_pond"
+CRAFT_FACILITY = "crafting"
+WEEK_MINUTES = 7 * 24 * 60
+
+
+@dataclass(slots=True)
+class SaleItem:
+    item_id: int
+    ability_id: int
+    ability_level: int
+    sale_value: float
+    ratio: float
+    name: str
+    category: str
+
+
+@dataclass(slots=True)
+class PlantGrowth:
+    seed_id: int
+    harvest_item_id: int
+    growth_time_sec: int
+    accelerated_time_sec: int
+    average_yield: float
+    farmland_ids: List[int]
+
+    @property
+    def cycle_minutes(self) -> float:
+        return self.accelerated_time_sec / 60.0
+
+    @property
+    def minutes_per_item(self) -> float:
+        if self.average_yield <= 0:
+            return math.inf
+        return self.cycle_minutes / self.average_yield
+
+
+@dataclass(slots=True)
+class FishGrowth:
+    fry_id: int
+    fish_id: int
+    growth_time_sec: int
+    accelerated_time_sec: int
+    name: str
+    yield_per_cycle: float = 1.0
+
+    @property
+    def cycle_minutes(self) -> float:
+        return self.accelerated_time_sec / 60.0
+
+    @property
+    def minutes_per_item(self) -> float:
+        if self.yield_per_cycle <= 0:
+            return math.inf
+        return self.cycle_minutes / self.yield_per_cycle
+
+
+@dataclass(slots=True)
+class MaterialRequirement:
+    item_id: int
+    quantity: float
+
+
+@dataclass(slots=True)
+class ComponentRequirement:
+    item_id: int
+    name: str
+    quantity: float
+    profile: Optional["ProductionProfile"]
+    exchange_cost: Optional[int]
+
+
+@dataclass(slots=True)
+class ProductionProfile:
+    item_id: int
+    name: str
+    sale_value: float
+    ability_id: int
+    ability_level: int
+    category: str
+    facility_minutes: Dict[str, float]
+    components: List[ComponentRequirement]
+    notes: List[str]
+
+    def facility_summary(self) -> Dict[str, float]:
+        return {k: round(v, 2) for k, v in self.facility_minutes.items() if v > 0}
+
+
+def _parse_numbers(text: str) -> List[float]:
+    numbers = re.findall(r"\d+(?:\.\d+)?", text or "")
+    return [float(value) for value in numbers]
+
+
+def _parse_average(text: str, fallback: float = 1.0) -> float:
+    numbers = _parse_numbers(text)
+    if not numbers:
+        return fallback
+    return sum(numbers) / len(numbers)
+
+
+class ProductionCalculator:
+    """Builds production profiles for saleable items."""
+
+    def __init__(self, loader: RemoteDataLoader, localization: Localization) -> None:
+        self._loader = loader
+        self._localization = localization
+        self.sale_items = self._load_sale_items()
+        self.plant_growth = self._load_plant_growth()
+        self.fish_growth = self._load_fish_growth()
+        self.furniture_recipes = self._load_furniture_recipes()
+        self.exchange_costs = self._load_exchange_costs()
+        self._profile_cache: Dict[int, ProductionProfile] = {}
+
+    def _load_sale_items(self) -> Dict[int, SaleItem]:
+        raw = self._loader.fetch_json("TbHomeProductsSaleInfo")
+        sale_items: Dict[int, SaleItem] = {}
+        for entry in raw.values():
+            item_id = int(entry["item_id"])
+            ability_id = int(entry["ability_id"])
+            ability_level = int(entry.get("ability_level", 0))
+            ratio = float(entry.get("ratio", 0))
+            rewards = entry.get("rewards", []) or []
+            sale_value = sum(
+                float(reward.get("num", 0))
+                for reward in rewards
+                if int(reward.get("item_id", 0)) == 14
+            )
+            name = self._localization.item_name(item_id)
+            category = ABILITY_CATEGORY.get(ability_id, "other")
+            sale_items[item_id] = SaleItem(
+                item_id=item_id,
+                ability_id=ability_id,
+                ability_level=ability_level,
+                sale_value=sale_value,
+                ratio=ratio,
+                name=name,
+                category=category,
+            )
+        return sale_items
+
+    def _load_plant_growth(self) -> Dict[int, PlantGrowth]:
+        growth_data = self._loader.fetch_json("TbPlantingGrowthProcess")
+        nutrient_data = self._loader.fetch_json("TbPlantingNutrient")
+        default_speedup = 0
+        for entry in nutrient_data.values():
+            if int(entry.get("consume_count", 0)) == 0:
+                default_speedup = int(entry.get("speedup_time", 0))
+                break
+        plant_growth: Dict[int, PlantGrowth] = {}
+        for entry in growth_data.values():
+            harvest_item = int(entry.get("harvest_item", 0))
+            if not harvest_item:
+                continue
+            stages = entry.get("growth_stages", []) or []
+            growth_time_sec = sum(int(stage.get("duration", 0)) for stage in stages)
+            accelerated = max(0, growth_time_sec - default_speedup)
+            average_yield = _parse_average(entry.get("estimate_harvests", "1"), fallback=1.0)
+            farmland_ids = [int(fid) for fid in entry.get("compatible_farmland", []) or []]
+            plant_growth[harvest_item] = PlantGrowth(
+                seed_id=int(entry["seed"]),
+                harvest_item_id=harvest_item,
+                growth_time_sec=growth_time_sec,
+                accelerated_time_sec=accelerated,
+                average_yield=average_yield,
+                farmland_ids=farmland_ids,
+            )
+        return plant_growth
+
+    def _load_fish_growth(self) -> Dict[int, FishGrowth]:
+        growth_data = self._loader.fetch_json("TbHomeFishGrowthConfig")
+        nutrient_data = self._loader.fetch_json("TbHomeFishNutrientConfig")
+        default_speedup = 0
+        for entry in nutrient_data.values():
+            if int(entry.get("consume_count", 0)) == 0:
+                default_speedup = int(entry.get("accelerate_time", 0))
+                break
+        fish_growth_by_name: Dict[str, FishGrowth] = {}
+        for entry in growth_data.values():
+            fish_id = int(entry.get("fish_id", 0))
+            name = self._localization.get(f"FISH_{fish_id}")
+            if not name:
+                continue
+            growth_time = int(entry.get("growth_time", 0))
+            accelerated = max(0, growth_time - default_speedup)
+            fish_growth_by_name[name.lower()] = FishGrowth(
+                fry_id=int(entry.get("fry_id", 0)),
+                fish_id=fish_id,
+                growth_time_sec=growth_time,
+                accelerated_time_sec=accelerated,
+                name=name,
+            )
+        # Map sale item IDs to growth data via the localised name.
+        fish_growth: Dict[int, FishGrowth] = {}
+        for sale in self.sale_items.values():
+            if sale.category != "fish":
+                continue
+            key = sale.name.lower()
+            if key in fish_growth_by_name:
+                fish_growth[sale.item_id] = fish_growth_by_name[key]
+        return fish_growth
+
+    def _load_furniture_recipes(self) -> Dict[int, List[MaterialRequirement]]:
+        raw = self._loader.fetch_json("TbFurnitureTableMakeInfo")
+        recipes: Dict[int, List[MaterialRequirement]] = {}
+        for entry in raw.values():
+            furniture_id = int(entry["furniture_id"])
+            materials = [
+                MaterialRequirement(item_id=int(material["item_id"]), quantity=float(material.get("num", 0)))
+                for material in entry.get("material_consume", []) or []
+            ]
+            time_minutes = float(entry.get("time", 0))
+            recipes[furniture_id] = materials
+            # We store craft time separately in a helper mapping.
+            entry["_time_minutes"] = time_minutes
+        self._furniture_time: Dict[int, float] = {
+            int(entry["furniture_id"]): float(entry.get("_time_minutes", 0))
+            for entry in raw.values()
+        }
+        return recipes
+
+    def _load_exchange_costs(self) -> Dict[int, int]:
+        raw = self._loader.fetch_json("TbFurnitureMakeMaterialExchangeInfo")
+        return {int(entry["material_item_id"]): int(entry.get("exchange_ratio", 0)) for entry in raw.values()}
+
+    def compute_profile(self, item_id: int) -> Optional[ProductionProfile]:
+        return self._compute_profile(item_id, stack=set())
+
+    def _compute_profile(self, item_id: int, stack: set[int]) -> Optional[ProductionProfile]:
+        if item_id in self._profile_cache:
+            return self._profile_cache[item_id]
+        if item_id in stack:
+            return None
+        sale = self.sale_items.get(item_id)
+        if not sale:
+            return None
+        stack.add(item_id)
+        if sale.category == "plant":
+            profile = self._build_plant_profile(sale)
+        elif sale.category == "fish":
+            profile = self._build_fish_profile(sale)
+        elif sale.category == "furniture":
+            profile = self._build_furniture_profile(sale, stack)
+        else:
+            profile = self._build_basic_profile(sale)
+        stack.remove(item_id)
+        if profile:
+            self._profile_cache[item_id] = profile
+        return profile
+
+    def _build_basic_profile(self, sale: SaleItem) -> ProductionProfile:
+        notes = [f"Production data for {sale.category} items is not yet modelled."]
+        return ProductionProfile(
+            item_id=sale.item_id,
+            name=sale.name,
+            sale_value=sale.sale_value,
+            ability_id=sale.ability_id,
+            ability_level=sale.ability_level,
+            category=sale.category,
+            facility_minutes={},
+            components=[],
+            notes=notes,
+        )
+
+    def _build_plant_profile(self, sale: SaleItem) -> ProductionProfile:
+        growth = self.plant_growth.get(sale.item_id)
+        facility_minutes: Dict[str, float] = {}
+        notes: List[str] = []
+        if growth:
+            facility_minutes[PLANT_FACILITY] = growth.minutes_per_item
+        else:
+            notes.append("No planting data available; timing estimates missing.")
+        return ProductionProfile(
+            item_id=sale.item_id,
+            name=sale.name,
+            sale_value=sale.sale_value,
+            ability_id=sale.ability_id,
+            ability_level=sale.ability_level,
+            category=sale.category,
+            facility_minutes=facility_minutes,
+            components=[],
+            notes=notes,
+        )
+
+    def _build_fish_profile(self, sale: SaleItem) -> ProductionProfile:
+        growth = self.fish_growth.get(sale.item_id)
+        facility_minutes: Dict[str, float] = {}
+        notes: List[str] = []
+        if growth:
+            facility_minutes[FISH_FACILITY] = growth.minutes_per_item
+        else:
+            notes.append("No fish growth data available; timing estimates missing.")
+        return ProductionProfile(
+            item_id=sale.item_id,
+            name=sale.name,
+            sale_value=sale.sale_value,
+            ability_id=sale.ability_id,
+            ability_level=sale.ability_level,
+            category=sale.category,
+            facility_minutes=facility_minutes,
+            components=[],
+            notes=notes,
+        )
+
+    def _build_furniture_profile(self, sale: SaleItem, stack: set[int]) -> ProductionProfile:
+        materials = self.furniture_recipes.get(sale.item_id, [])
+        facility_minutes: Dict[str, float] = {CRAFT_FACILITY: self._furniture_time.get(sale.item_id, 0.0)}
+        components: List[ComponentRequirement] = []
+        notes: List[str] = []
+        if not materials:
+            notes.append("Furniture recipe not found in extracted data.")
+        for requirement in materials:
+            component_profile = self._compute_profile(int(requirement.item_id), stack)
+            component_name = self._localization.item_name(requirement.item_id)
+            exchange_cost = self.exchange_costs.get(requirement.item_id)
+            components.append(
+                ComponentRequirement(
+                    item_id=requirement.item_id,
+                    name=component_name,
+                    quantity=requirement.quantity,
+                    profile=component_profile,
+                    exchange_cost=exchange_cost,
+                )
+            )
+            if component_profile:
+                for facility, minutes in component_profile.facility_minutes.items():
+                    facility_minutes[facility] = facility_minutes.get(facility, 0.0) + minutes * requirement.quantity
+        return ProductionProfile(
+            item_id=sale.item_id,
+            name=sale.name,
+            sale_value=sale.sale_value,
+            ability_id=sale.ability_id,
+            ability_level=sale.ability_level,
+            category=sale.category,
+            facility_minutes=facility_minutes,
+            components=components,
+            notes=notes,
+        )
+
+    def supported_profiles(self) -> List[ProductionProfile]:
+        profiles: List[ProductionProfile] = []
+        for item_id in self.sale_items:
+            profile = self.compute_profile(item_id)
+            if profile:
+                profiles.append(profile)
+        return profiles
+

--- a/astralite_optimizer/progression.py
+++ b/astralite_optimizer/progression.py
@@ -1,0 +1,80 @@
+"""Player progression helpers derived from the extracted datasets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping
+
+
+@dataclass(slots=True)
+class LevelReward:
+    ability_id: int
+    level: int
+    items: Dict[int, int]
+
+
+@dataclass(slots=True)
+class TotalLevelBonus:
+    level: int
+    weekly_bonus: int
+
+
+class ProgressionRepository:
+    """Aggregates level-up rewards and weekly bonuses."""
+
+    def __init__(
+        self,
+        reward_data: Mapping[str, Mapping],
+        total_level_data: Mapping[str, Mapping],
+    ) -> None:
+        self._rewards_by_ability: Dict[int, List[LevelReward]] = {}
+        for entry in reward_data.values():
+            raw_id = int(entry["id"])
+            ability_id = raw_id // 1000
+            level = raw_id % 1000
+            items: Dict[int, int] = {}
+            for reward in entry.get("des_item", []) or []:
+                item_id = int(reward.get("item_id", 0))
+                if not item_id:
+                    continue
+                items[item_id] = items.get(item_id, 0) + int(reward.get("num", 0))
+            self._rewards_by_ability.setdefault(ability_id, []).append(
+                LevelReward(ability_id=ability_id, level=level, items=items)
+            )
+
+        for rewards in self._rewards_by_ability.values():
+            rewards.sort(key=lambda reward: reward.level)
+
+        self._total_level_bonuses: List[TotalLevelBonus] = [
+            TotalLevelBonus(level=int(entry["level"]), weekly_bonus=int(entry.get("gold_weekmax", 0)))
+            for entry in total_level_data.values()
+        ]
+        self._total_level_bonuses.sort(key=lambda bonus: bonus.level)
+
+    def ability_reward_items(self, ability_id: int, level: int) -> Dict[int, int]:
+        """Return the cumulative item quantities unlocked up to ``level``."""
+
+        totals: Dict[int, int] = {}
+        for reward in self._rewards_by_ability.get(ability_id, []):
+            if reward.level > level:
+                break
+            for item_id, qty in reward.items.items():
+                totals[item_id] = totals.get(item_id, 0) + qty
+        return totals
+
+    def sum_item_counts(self, ability_id: int, level: int, item_ids: Iterable[int]) -> int:
+        reward_totals = self.ability_reward_items(ability_id, level)
+        return sum(reward_totals.get(item_id, 0) for item_id in item_ids)
+
+    def max_level(self, ability_id: int) -> int:
+        rewards = self._rewards_by_ability.get(ability_id, [])
+        return rewards[-1].level if rewards else 0
+
+    def weekly_bonus_for_total_level(self, total_level: int) -> int:
+        bonus = 0
+        for entry in self._total_level_bonuses:
+            if entry.level > total_level:
+                break
+            bonus = entry.weekly_bonus
+        return bonus
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+httpx
+pulp
+requests
+uvicorn
+pytest

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,483 @@
+const state = {
+  abilities: [],
+  items: [],
+  selectedBonuses: [],
+  facilityNames: {},
+  baseWeeklyLimit: 0,
+};
+
+const elements = {
+  abilityInputs: document.getElementById("ability-inputs"),
+  bonusSearch: document.getElementById("bonus-search"),
+  bonusOptions: document.getElementById("bonus-options"),
+  selectedBonuses: document.getElementById("selected-bonuses"),
+  addBonus: document.getElementById("add-bonus"),
+  craftingSlots: document.getElementById("crafting-slots"),
+  calculate: document.getElementById("calculate"),
+  status: document.getElementById("status"),
+  summarySection: document.getElementById("summary-section"),
+  summaryMetrics: document.getElementById("summary-metrics"),
+  facilitySummary: document.getElementById("facility-summary"),
+  planSection: document.getElementById("plan-section"),
+  planBody: document.getElementById("plan-body"),
+  planMessage: document.getElementById("plan-message"),
+  facilityBody: document.getElementById("facility-body"),
+  detailSection: document.getElementById("detail-section"),
+  itemSelect: document.getElementById("item-select"),
+  itemDetails: document.getElementById("item-details"),
+};
+
+const FACILITY_ORDER = ["plant_plot", "fish_pond", "crafting"];
+
+document.addEventListener("DOMContentLoaded", () => {
+  elements.addBonus.addEventListener("click", handleAddBonus);
+  elements.bonusSearch.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      handleAddBonus();
+    }
+  });
+  elements.calculate.addEventListener("click", handleCalculate);
+  elements.itemSelect.addEventListener("change", () => {
+    const itemId = Number(elements.itemSelect.value);
+    renderItemDetails(itemId);
+  });
+
+  loadInitialData().catch((error) => {
+    setStatus(`Failed to initialise optimiser: ${error.message}`, true);
+  });
+});
+
+async function loadInitialData() {
+  setStatus("Loading game data from GitHub…");
+  const response = await fetch("/api/init");
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  state.abilities = data.abilities || [];
+  state.items = data.items || [];
+  state.facilityNames = data.facility_names || {};
+  state.baseWeeklyLimit = data.base_weekly_limit || 0;
+  renderAbilityInputs();
+  renderBonusOptions();
+  renderItemSelect();
+  elements.detailSection.classList.remove("hidden");
+  setStatus("Ready. Choose your ability levels, boosted items, and compute the plan.");
+}
+
+function renderAbilityInputs() {
+  elements.abilityInputs.innerHTML = "";
+  state.abilities.forEach((ability) => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "form-row ability";
+
+    const label = document.createElement("label");
+    label.textContent = `${ability.label} level`;
+    label.setAttribute("for", `ability-${ability.id}`);
+
+    const input = document.createElement("input");
+    input.type = "number";
+    input.min = "0";
+    input.max = String(ability.max_level || 60);
+    input.value = String(Math.min(ability.max_level || 0, 10));
+    input.id = `ability-${ability.id}`;
+    input.dataset.abilityId = String(ability.id);
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(input);
+    elements.abilityInputs.appendChild(wrapper);
+  });
+}
+
+function renderBonusOptions() {
+  elements.bonusOptions.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  state.items.forEach((item) => {
+    const option = document.createElement("option");
+    option.value = item.name;
+    option.label = item.category ? `${item.name} (${capitalize(item.category)})` : item.name;
+    fragment.appendChild(option);
+  });
+  elements.bonusOptions.appendChild(fragment);
+}
+
+function handleAddBonus() {
+  const query = elements.bonusSearch.value.trim();
+  if (!query) {
+    return;
+  }
+  const match = findItemByName(query);
+  if (!match) {
+    setStatus(`No item found matching “${query}”.`, true);
+    return;
+  }
+  addBonus(match);
+  elements.bonusSearch.value = "";
+}
+
+function findItemByName(query) {
+  const lower = query.toLowerCase();
+  return (
+    state.items.find((item) => item.name.toLowerCase() === lower) ||
+    state.items.find((item) => item.name.toLowerCase().includes(lower)) ||
+    null
+  );
+}
+
+function addBonus(item) {
+  if (state.selectedBonuses.some((entry) => entry.item_id === item.item_id)) {
+    return;
+  }
+  if (state.selectedBonuses.length >= 4) {
+    setStatus("Only four items can receive the weekly bonus.", true);
+    return;
+  }
+  state.selectedBonuses.push({ item_id: item.item_id, name: item.name });
+  updateSelectedBonuses();
+}
+
+function removeBonus(itemId) {
+  state.selectedBonuses = state.selectedBonuses.filter((entry) => entry.item_id !== itemId);
+  updateSelectedBonuses();
+}
+
+function updateSelectedBonuses() {
+  elements.selectedBonuses.innerHTML = "";
+  if (!state.selectedBonuses.length) {
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  state.selectedBonuses.forEach((entry) => {
+    const chip = document.createElement("div");
+    chip.className = "chip";
+    chip.textContent = entry.name;
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.setAttribute("aria-label", `Remove ${entry.name}`);
+    removeButton.textContent = "×";
+    removeButton.addEventListener("click", () => removeBonus(entry.item_id));
+
+    chip.appendChild(removeButton);
+    fragment.appendChild(chip);
+  });
+  elements.selectedBonuses.appendChild(fragment);
+}
+
+function gatherAbilityLevels() {
+  const inputs = elements.abilityInputs.querySelectorAll("input[data-ability-id]");
+  const levels = {};
+  inputs.forEach((input) => {
+    const abilityId = Number(input.dataset.abilityId);
+    const value = Number(input.value || 0);
+    levels[abilityId] = Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+  });
+  return levels;
+}
+
+async function handleCalculate() {
+  const abilityLevels = gatherAbilityLevels();
+  const craftingSlots = Math.max(1, Math.floor(Number(elements.craftingSlots.value || 1)));
+  const bonusItemIds = state.selectedBonuses.map((entry) => entry.item_id);
+
+  elements.calculate.disabled = true;
+  setStatus("Calculating optimal plan…");
+
+  try {
+    const response = await fetch("/api/optimise", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ability_levels: abilityLevels, bonus_item_ids: bonusItemIds, crafting_slots: craftingSlots }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const data = await response.json();
+    renderResults(data);
+    setStatus(`Optimisation complete — status: ${data.status}`);
+  } catch (error) {
+    console.error(error);
+    setStatus(`Failed to optimise: ${error.message}`, true);
+  } finally {
+    elements.calculate.disabled = false;
+  }
+}
+
+function renderResults(data) {
+  renderSummary(data);
+  renderPlanTable(data);
+}
+
+function renderSummary(data) {
+  elements.summaryMetrics.innerHTML = "";
+  elements.facilitySummary.innerHTML = "";
+
+  const metrics = [
+    createMetric("Weekly Astralite limit", formatNumber(data.weekly_limit || state.baseWeeklyLimit)),
+    createMetric("Ability evaluation", formatNumber(data.ability_total || 0)),
+    createMetric("Weekly bonus", formatNumber(data.weekly_bonus || 0)),
+    createMetric("Plant plots", formatNumber(data.plant_plots || 0)),
+    createMetric("Fish ponds", formatNumber(data.fish_ponds || 0)),
+    createMetric("Crafting slots", formatNumber(data.crafting_slots || 0)),
+  ];
+  metrics.forEach((metric) => elements.summaryMetrics.appendChild(metric));
+
+  const facilityUsage = data.facility_usage || {};
+  const capacities = data.capacities || {};
+  FACILITY_ORDER.forEach((key) => {
+    if (!(key in capacities)) {
+      return;
+    }
+    const usage = facilityUsage[key] || { minutes: 0, hours: 0 };
+    const capacity = capacities[key] || { minutes: 0, hours: 0 };
+    const utilisation = capacity.hours ? ((usage.hours / capacity.hours) * 100).toFixed(1) : "0.0";
+    const metric = createMetric(state.facilityNames[key] || key, `${formatHours(usage.hours)} / ${formatHours(capacity.hours)} hrs (${utilisation}% used)`);
+    elements.facilitySummary.appendChild(metric);
+  });
+
+  elements.summarySection.classList.remove("hidden");
+}
+
+function renderPlanTable(data) {
+  elements.planBody.innerHTML = "";
+  const items = data.items || [];
+  if (!items.length) {
+    elements.planMessage.textContent = data.message || "No production items selected yet.";
+    elements.planSection.classList.remove("hidden");
+    elements.planBody.innerHTML = "";
+    elements.facilityBody.innerHTML = "";
+    return;
+  }
+
+  elements.planMessage.textContent = "";
+  const fragment = document.createDocumentFragment();
+  items.forEach((item) => {
+    const row = document.createElement("tr");
+    appendCell(row, item.name);
+    appendCell(row, capitalize(item.category));
+    appendCell(row, formatNumber(item.units));
+    appendCell(row, formatNumber(item.astralite));
+    appendCell(row, formatNumber(item.per_unit_value));
+
+    FACILITY_ORDER.forEach((facility) => {
+      const minutes = item.facility_minutes?.[facility] || 0;
+      appendCell(row, formatHours(minutes / 60));
+    });
+
+    appendCell(row, item.multiplier > 1 ? "Yes" : "No");
+    fragment.appendChild(row);
+  });
+  elements.planBody.appendChild(fragment);
+  elements.planSection.classList.remove("hidden");
+
+  const facilityUsage = data.facility_usage || {};
+  const capacities = data.capacities || {};
+  elements.facilityBody.innerHTML = "";
+  const facilityFragment = document.createDocumentFragment();
+  FACILITY_ORDER.forEach((facility) => {
+    if (!(facility in capacities)) {
+      return;
+    }
+    const usage = facilityUsage[facility] || { hours: 0 };
+    const capacity = capacities[facility] || { hours: 0 };
+    const usedHours = usage.hours || 0;
+    const capacityHours = capacity.hours || 0;
+    const utilisation = capacityHours ? ((usedHours / capacityHours) * 100).toFixed(1) : "0.0";
+
+    const row = document.createElement("tr");
+    appendCell(row, state.facilityNames[facility] || facility);
+    appendCell(row, formatHours(usedHours));
+    appendCell(row, formatHours(capacityHours));
+    appendCell(row, `${utilisation}%`);
+    facilityFragment.appendChild(row);
+  });
+  elements.facilityBody.appendChild(facilityFragment);
+}
+
+
+function renderItemSelect() {
+  elements.itemSelect.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  state.items
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .forEach((item) => {
+      const option = document.createElement("option");
+      option.value = String(item.item_id);
+      option.textContent = item.name;
+      fragment.appendChild(option);
+    });
+  elements.itemSelect.appendChild(fragment);
+  if (state.items.length) {
+    elements.itemSelect.value = String(state.items[0].item_id);
+    renderItemDetails(state.items[0].item_id);
+  }
+}
+
+function renderItemDetails(itemId) {
+  const profile = state.items.find((item) => item.item_id === Number(itemId));
+  if (!profile) {
+    elements.itemDetails.innerHTML = "<p>Select an item to inspect.</p>";
+    return;
+  }
+  const ability = state.abilities.find((entry) => entry.id === profile.ability_id);
+  const abilityLabel = ability ? ability.label : `Ability ${profile.ability_id}`;
+
+  const summaryLines = [
+    `<p><strong>Category:</strong> ${capitalize(profile.category)} · <strong>Sale value:</strong> ${formatNumber(profile.sale_value)} Astralite</p>`,
+    `<p><strong>Requirement:</strong> ${abilityLabel} level ${profile.ability_level}</p>`,
+  ];
+
+  const facilityList = formatFacilityList(profile.facility_minutes);
+  if (facilityList.length) {
+    summaryLines.push(`<p><strong>Per-unit facility time:</strong> ${facilityList.join(", ")}</p>`);
+  } else {
+    summaryLines.push("<p>No facility timing data available.</p>");
+  }
+
+  const detail = profile.detail || {};
+  if (detail.category === "plant" && detail.growth_minutes) {
+    summaryLines.push(
+      `<p>Growth cycle: ${formatNumber(detail.growth_minutes)} minutes (~${formatHours(detail.growth_minutes / 60)} hrs) for an average yield of ${formatNumber(detail.average_yield || 0)}.</p>`
+    );
+  } else if (detail.category === "fish" && detail.growth_minutes) {
+    summaryLines.push(
+      `<p>Growth time: ${formatNumber(detail.growth_minutes)} minutes (~${formatHours(detail.growth_minutes / 60)} hrs) per fish.</p>`
+    );
+  } else if (detail.category === "furniture" && detail.craft_minutes) {
+    summaryLines.push(
+      `<p>Crafting queue time: ${formatNumber(detail.craft_minutes)} minutes (~${formatHours(detail.craft_minutes / 60)} hrs) per item.</p>`
+    );
+  }
+
+  let componentsHtml = "<p>No crafting prerequisites.</p>";
+  if (profile.components && profile.components.length) {
+    const rows = profile.components
+      .map((component) => formatComponentRow(component))
+      .join("");
+    componentsHtml = `
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th>Qty</th>
+              <th>Category</th>
+              <th>Plant hrs</th>
+              <th>Fish hrs</th>
+              <th>Craft hrs</th>
+              <th>Exchange cost</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
+  let notesHtml = "";
+  if (profile.notes && profile.notes.length) {
+    const notes = profile.notes.map((note) => `<li>${escapeHtml(note)}</li>`).join("");
+    notesHtml = `<div><h4>Notes</h4><ul>${notes}</ul></div>`;
+  }
+
+  elements.itemDetails.innerHTML = `
+    <div>
+      <h3>${escapeHtml(profile.name)}</h3>
+      ${summaryLines.join("")}
+      <h4>Components</h4>
+      ${componentsHtml}
+      ${notesHtml}
+    </div>
+  `;
+}
+
+function formatComponentRow(component) {
+  const facilityMinutes = component.total_facility_minutes || {};
+  const perUnitMinutes = component.facility_minutes || {};
+  const notes = component.notes && component.notes.length ? component.notes.map(escapeHtml).join("; ") : "";
+  const exchange = component.exchange_cost ? `${formatNumber(component.exchange_cost)} Astralite` : "—";
+
+  const cells = [
+    `<td>${escapeHtml(component.name)}</td>`,
+    `<td>${formatNumber(component.quantity)}</td>`,
+    `<td>${component.category ? capitalize(component.category) : "—"}</td>`,
+  ];
+
+  FACILITY_ORDER.forEach((facility) => {
+    const total = facilityMinutes[facility] || 0;
+    const perUnit = perUnitMinutes[facility] || 0;
+    const value = total ? `${formatHours(total / 60)} hrs` : "—";
+    const title = perUnit ? `Per unit: ${formatHours(perUnit / 60)} hrs` : "";
+    cells.push(`<td title="${title}">${value}</td>`);
+  });
+
+  cells.push(`<td>${exchange}</td>`);
+  cells.push(`<td>${notes}</td>`);
+  return `<tr>${cells.join("")}</tr>`;
+}
+
+function createMetric(label, value) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "metric";
+  const heading = document.createElement("h3");
+  heading.textContent = label;
+  const text = document.createElement("p");
+  text.textContent = value;
+  wrapper.appendChild(heading);
+  wrapper.appendChild(text);
+  return wrapper;
+}
+
+function appendCell(row, value) {
+  const cell = document.createElement("td");
+  cell.textContent = value;
+  row.appendChild(cell);
+}
+
+function formatFacilityList(minutesMap) {
+  if (!minutesMap) {
+    return [];
+  }
+  return FACILITY_ORDER.filter((facility) => facility in minutesMap).map((facility) => {
+    const minutes = minutesMap[facility];
+    return `${state.facilityNames[facility] || capitalize(facility)}: ${formatNumber(minutes)} min (${formatHours(minutes / 60)} hrs)`;
+  });
+}
+
+function setStatus(message, isError = false) {
+  elements.status.textContent = message;
+  elements.status.classList.toggle("error", Boolean(isError));
+}
+
+function capitalize(value) {
+  if (!value) {
+    return "";
+  }
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatNumber(value) {
+  const number = Number(value) || 0;
+  if (Math.abs(number) >= 1000) {
+    return number.toLocaleString("en-US", { maximumFractionDigits: 1 });
+  }
+  return number.toLocaleString("en-US", { maximumFractionDigits: 2, minimumFractionDigits: number % 1 === 0 ? 0 : 2 });
+}
+
+function formatHours(value) {
+  const number = Number(value) || 0;
+  return number.toLocaleString("en-US", { maximumFractionDigits: 2, minimumFractionDigits: 0 });
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Astralite Optimiser</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <h1>Astralite Optimiser</h1>
+        <p>
+          Plan your weekly Astralite exchanges with Posy using live Infinity Nikki
+          housing data pulled directly from
+          <a href="https://github.com/kateberly/Astralite" target="_blank" rel="noreferrer">kateberly/Astralite</a>.
+        </p>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="card" id="player-setup">
+        <h2>Player setup</h2>
+        <div id="ability-inputs" class="grid"></div>
+        <div class="form-row">
+          <label for="crafting-slots">Crafting queue slots</label>
+          <input id="crafting-slots" type="number" min="1" value="1" step="1" />
+        </div>
+      </section>
+
+      <section class="card" id="bonus-section">
+        <h2>Weekly 1.2× items</h2>
+        <div class="form-row inline">
+          <input
+            id="bonus-search"
+            type="search"
+            placeholder="Search item name"
+            list="bonus-options"
+            autocomplete="off"
+          />
+          <datalist id="bonus-options"></datalist>
+          <button id="add-bonus" type="button" class="secondary">Add item</button>
+        </div>
+        <p class="hint">Add up to four items that receive the 1.2× Astralite bonus.</p>
+        <div id="selected-bonuses" class="chip-container"></div>
+      </section>
+
+      <section class="card" id="actions">
+        <button id="calculate" type="button" class="primary">Compute optimal plan</button>
+        <div id="status" class="status"></div>
+      </section>
+
+      <section class="card hidden" id="summary-section">
+        <h2>Weekly summary</h2>
+        <div id="summary-metrics" class="metric-grid"></div>
+        <div id="facility-summary" class="metric-grid"></div>
+      </section>
+
+      <section class="card hidden" id="plan-section">
+        <h2>Optimised production plan</h2>
+        <p id="plan-message" class="hint"></p>
+        <div class="table-wrapper">
+          <table id="plan-table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Category</th>
+                <th>Units</th>
+                <th>Astralite</th>
+                <th>Value / unit</th>
+                <th>Plant hrs</th>
+                <th>Fish hrs</th>
+                <th>Craft hrs</th>
+                <th>Weekly bonus</th>
+              </tr>
+            </thead>
+            <tbody id="plan-body"></tbody>
+          </table>
+        </div>
+
+        <div class="table-wrapper">
+          <table id="facility-table">
+            <thead>
+              <tr>
+                <th>Facility</th>
+                <th>Used (hrs)</th>
+                <th>Capacity (hrs)</th>
+                <th>Utilisation %</th>
+              </tr>
+            </thead>
+            <tbody id="facility-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="card hidden" id="detail-section">
+        <h2>Item details</h2>
+        <div class="form-row">
+          <label for="item-select">Inspect item</label>
+          <select id="item-select"></select>
+        </div>
+        <div id="item-details" class="details"></div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Built for Infinity Nikki housing enthusiasts. Optimisation powered by linear programming, data sourced live from GitHub.
+      </p>
+    </footer>
+
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,293 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1c2534;
+}
+
+.hero {
+  background: linear-gradient(135deg, #3c74ff, #6a9bff);
+  color: #fff;
+  padding: 3rem 1.5rem;
+}
+
+.hero__content {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.5rem;
+}
+
+.hero p {
+  margin: 0;
+  max-width: 720px;
+}
+
+.hero a {
+  color: #ffe8a3;
+  font-weight: 600;
+}
+
+.layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(28, 37, 52, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 1rem;
+}
+
+.form-row.inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+label {
+  font-weight: 600;
+  color: #405168;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+input,
+select {
+  border: 1px solid #c8d4ec;
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  transition: border-color 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: #3c74ff;
+  box-shadow: 0 0 0 2px rgba(60, 116, 255, 0.15);
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #3c74ff, #5a8dff);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 10px 18px rgba(60, 116, 255, 0.35);
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 24px rgba(60, 116, 255, 0.45);
+}
+
+button.secondary {
+  background: #eef3ff;
+  color: #3450a1;
+  font-weight: 600;
+}
+
+button.secondary:hover {
+  background: #dfe8ff;
+}
+
+.chip-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #eef2ff;
+  color: #263d7a;
+  border-radius: 999px;
+  padding: 0.25rem 0.85rem;
+}
+
+.chip button {
+  background: transparent;
+  border: none;
+  color: #263d7a;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.status {
+  margin-top: 1rem;
+  min-height: 1.5rem;
+  color: #20345a;
+  font-weight: 600;
+}
+
+.status.error {
+  color: #b00020;
+}
+
+.hint {
+  color: #65738d;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.metric {
+  border-radius: 12px;
+  border: 1px solid #dbe4ff;
+  background: #f7f9ff;
+  padding: 1rem;
+}
+
+.metric h3 {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #4b5b80;
+}
+
+.metric p {
+  margin: 0.3rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  margin-top: 1rem;
+  border-radius: 12px;
+  border: 1px solid #e0e7ff;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+thead {
+  background: #eff3ff;
+}
+
+thead th {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: #4e5d7e;
+}
+
+th,
+td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #e6ecff;
+  text-align: left;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.details {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.details h3 {
+  margin: 0;
+}
+
+.details table {
+  min-width: 0;
+}
+
+.details table th,
+.details table td {
+  border-bottom: 1px solid #e6ecff;
+}
+
+.details ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: #5a6780;
+  font-size: 0.9rem;
+}
+
+.footer a {
+  color: inherit;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .form-row.inline {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  table {
+    min-width: 100%;
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,38 @@
+from fastapi.testclient import TestClient
+
+from app import app
+
+client = TestClient(app)
+
+
+def test_init_endpoint_returns_profiles():
+    response = client.get("/api/init")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert "abilities" in data and data["abilities"]
+    assert any(entry["label"] == "Construction" for entry in data["abilities"])
+    assert data["base_weekly_limit"] >= 100000
+    assert len(data["items"]) > 0
+    sample = data["items"][0]
+    assert {"item_id", "name", "category"}.issubset(sample)
+
+
+def test_optimise_endpoint_handles_bonus_items():
+    payload = {
+        "ability_levels": {"22": 40, "34": 40, "47": 40},
+        "bonus_item_ids": [1170000350],
+        "crafting_slots": 2,
+    }
+    response = client.post("/api/optimise", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["status"]
+    assert data["weekly_limit"] >= data["weekly_bonus"]
+    assert data["plant_plots"] >= 0
+    assert data["fish_ponds"] >= 0
+
+    for item in data.get("items", []):
+        assert item["multiplier"] in (1.0, 1.2)
+        assert item["per_unit_facility_minutes"] is not None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ def test_init_endpoint_returns_profiles():
     assert len(data["items"]) > 0
     sample = data["items"][0]
     assert {"item_id", "name", "category"}.issubset(sample)
+    assert all(item["facility_minutes"] for item in data["items"])
 
 
 def test_optimise_endpoint_handles_bonus_items():

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,57 @@
+import math
+
+from astralite_optimizer.data_loader import RemoteDataLoader
+from astralite_optimizer.localization import Localization
+from astralite_optimizer.production import (
+    CRAFT_FACILITY,
+    FISH_FACILITY,
+    PLANT_FACILITY,
+    ProductionCalculator,
+)
+from astralite_optimizer.progression import ProgressionRepository
+
+
+def _create_calculator():
+    loader = RemoteDataLoader()
+    localisation = Localization(loader.fetch_json("en"))
+    calculator = ProductionCalculator(loader, localisation)
+    return loader, calculator
+
+
+def test_cozy_bed_profile_has_expected_components():
+    loader, calculator = _create_calculator()
+    profile = calculator.compute_profile(1170000350)  # Cozy Bed
+
+    assert profile is not None
+    assert math.isclose(profile.facility_minutes.get(CRAFT_FACILITY, 0.0), 60.0, rel_tol=1e-6)
+    assert math.isclose(profile.facility_minutes.get(PLANT_FACILITY, 0.0), 100.0, rel_tol=1e-6)
+    assert math.isclose(profile.facility_minutes.get(FISH_FACILITY, 0.0), 3000.0, rel_tol=1e-6)
+
+    components = {component.name: component for component in profile.components}
+    assert "Golden Fragrant Cup" in components
+    assert components["Golden Fragrant Cup"].quantity == 50
+    assert math.isclose(
+        components["Golden Fragrant Cup"].profile.facility_minutes[PLANT_FACILITY],
+        2.0,
+        rel_tol=1e-6,
+    )
+    assert "Blinko Fish" in components
+    assert math.isclose(
+        components["Blinko Fish"].profile.facility_minutes[FISH_FACILITY],
+        100.0,
+        rel_tol=1e-6,
+    )
+
+
+def test_progression_bonus_and_plots():
+    loader = RemoteDataLoader()
+    progression = ProgressionRepository(
+        loader.fetch_json("TbHomeAbilityLevelUpRewardShowInfo"),
+        loader.fetch_json("TbHomeAbilityTotalLevelValueInfo"),
+    )
+
+    assert progression.weekly_bonus_for_total_level(1) == 0
+    assert progression.weekly_bonus_for_total_level(5) == 50000
+
+    plots = progression.sum_item_counts(34, 20, (1170000320, 1170000321, 1170000322, 1170000323))
+    assert plots == 26


### PR DESCRIPTION
## Summary
- replace the Streamlit script with a FastAPI backend that serves the optimiser API and static assets
- add an interactive HTML/JS frontend that loads live data, supports bonus-item search, and renders optimisation results with detailed recipes
- add automated API regression tests and update dependencies for the new web stack

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8e225493c833381d97aa1c333e43f